### PR TITLE
1.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,24 +4,24 @@
 import PackageDescription
 
 let package = Package(
-    name: "Groot",
+    name: "Ceroxylon",
     platforms: [
         .macOS(.v10_15)
     ],
     products: [
-        .executable(name: "Groot", targets: ["Groot"])
+        .executable(name: "Ceroxylon", targets: ["Ceroxylon"])
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0")
     ],
     targets: [
         .executableTarget(
-            name: "Groot",
+            name: "Ceroxylon",
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
         ]),
         .testTarget(
-            name: "GrootTests",
-            dependencies: ["Groot"])
+            name: "CeroxylonTests",
+            dependencies: ["Ceroxylon"])
     ]
 )

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ $ ./install.sh /usr/local/bin
 Ceroxylon should now be installed on /usr/local/bin and can be accessed via terminal.
 ```
 $ ceroxylon
+$ xylon
 ```
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ $ ceroxylon
 ```
 $ ceroxylon --help
 
-USAGE: ceroxylon [--path <path>] [--depth <depth>] [--hidden <hidden>]
+USAGE: ceroxylon [--path <path>] [--depth <depth>] [--hidden]
 
 OPTIONS:
   -p, --path <path>       The directory path
   -d, --depth <depth>     The depth of the generated tree (default: 100)
-  -h, --hidden <hidden>   Defines if generated tree includes hidden files. (default: false)
+      --hidden            Includes hidden files in the generated tree.
   -h, --help              Show help information.
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
-# Groot
+# Ceroxylon
 A command like tool to generate Tree representation from a given directory path
+
+### Why the name? 🌴
+
+Ceroxylon is inspired by *Ceroxylon quindiuense*, the Quindio wax palm, which is recognized as the national tree of Colombia. You can read more about it on [Wikipedia](https://en.wikipedia.org/wiki/Ceroxylon_quindiuense).
 
 ### Installation
 
-Clone Groot on your machine:
+Clone Ceroxylon on your machine:
 
 ```
-$ git clone https://github.com/jjotaum/Groot.git
+$ git clone https://github.com/jjotaum/Ceroxylon.git
 ```
 Navigate to it's directory:
 
 ```
-$ cd Groot
+$ cd Ceroxylon
 ```
 
 Execute install script
@@ -21,17 +25,17 @@ Run install script using a directory as parameter e.g: /usr/local/bin
 ```
 $ ./install.sh /usr/local/bin
 ```
-Groot should now be installed on /usr/local/bin and can be accessed via terminal.
+Ceroxylon should now be installed on /usr/local/bin and can be accessed via terminal.
 ```
-$ groot
+$ ceroxylon
 ```
 
 ### Usage
 
 ```
-$ groot --help
+$ ceroxylon --help
 
-USAGE: groot [--path <path>] [--depth <depth>] [--hidden <hidden>]
+USAGE: ceroxylon [--path <path>] [--depth <depth>] [--hidden <hidden>]
 
 OPTIONS:
   -p, --path <path>       The directory path
@@ -49,12 +53,12 @@ OPTIONS:
 ├── Package.swift
 ├── README.md
 ├── Sources
-│   ├── Groot
-│   │   ├── Groot.swift
+│   ├── Ceroxylon
+│   │   ├── Ceroxylon.swift
 │   │   ├── TreeGenerator.swift
 │   │   └── main.swift
 ├── Tests
-│   ├── GrootTests
-│   │   └── GrootTests.swift
+│   ├── CeroxylonTests
+│   │   └── CeroxylonTests.swift
 └── install.sh
 ```

--- a/Sources/Ceroxylon/Ceroxylon.swift
+++ b/Sources/Ceroxylon/Ceroxylon.swift
@@ -13,7 +13,7 @@ struct Ceroxylon: ParsableCommand {
     private var path: String?
     @Option(name: .shortAndLong, help: "The depth of the generated tree")
     private var depth: Int = 100
-    @Option(name: .shortAndLong, help: "Defines if generated tree includes hidden files.")
+    @Flag(name: .long, help: "Includes hidden files in the generated tree.")
     private var hidden: Bool = false
     
     func run() throws {

--- a/Sources/Ceroxylon/Ceroxylon.swift
+++ b/Sources/Ceroxylon/Ceroxylon.swift
@@ -1,6 +1,6 @@
 //
-//  Groot.swift
-//  Groot
+//  Ceroxylon.swift
+//  Ceroxylon
 //
 //  Created by Jota Uribe on 22/10/23.
 //
@@ -8,7 +8,7 @@
 import ArgumentParser
 import Foundation
 
-struct Groot: ParsableCommand {
+struct Ceroxylon: ParsableCommand {
     @Option(name: .shortAndLong, help: "The directory path")
     private var path: String?
     @Option(name: .shortAndLong, help: "The depth of the generated tree")

--- a/Sources/Ceroxylon/TreeGenerator.swift
+++ b/Sources/Ceroxylon/TreeGenerator.swift
@@ -1,6 +1,6 @@
 //
 //  TreeGenerator.swift
-//  Groot
+//  Ceroxylon
 //
 //  Created by Jota Uribe on 22/10/23.
 //

--- a/Sources/Ceroxylon/main.swift
+++ b/Sources/Ceroxylon/main.swift
@@ -1,10 +1,9 @@
 //
 //  main.swift
-//  Groot
+//  Ceroxylon
 //
 //  Created by Jota Uribe on 21/10/23.
 //
 
 import Foundation
-Groot.main()
-
+Ceroxylon.main()

--- a/Sources/Groot/TreeGenerator.swift
+++ b/Sources/Groot/TreeGenerator.swift
@@ -16,18 +16,19 @@ struct TreeGenerator {
     func generate() throws {
         guard let url = URL(string: path) else { throw URLError(.badURL) }
         print("```")
-        try generate(url: url, depth: depth)
+        try generate(url: url, depth: depth, prefix: "")
         print("```")
     }
     
-    func generate(url: URL, depth: Int, parent: String = "") throws {
+    func generate(url: URL, depth: Int, prefix: String) throws {
         let contents = try fileManager.contentsOfDirectory(at: url, includingPropertiesForKeys: nil, options: includesHidden ? [] : [.skipsHiddenFiles]).sorted(by: { $0.lastPathComponent < $1.lastPathComponent })
-        let spacer = parent.isEmpty ? "" : "   "
-        try contents.forEach { content in
-            let suffix = content == contents.last && !content.hasDirectoryPath ? "└──" : "├──"
-            print("\(parent)\(spacer)\(suffix) \(content.lastPathComponent)")
-            guard depth > .zero && content.hasDirectoryPath else { return }
-            try generate(url: content, depth: depth - 1, parent: parent.isEmpty ? "│" : "\(parent)\(spacer)│")
+        for (index, content) in contents.enumerated() {
+            let isLast = index == contents.count - 1
+            let branch = isLast ? "└── " : "├── "
+            print("\(prefix)\(branch)\(content.lastPathComponent)")
+            guard depth > .zero && content.hasDirectoryPath else { continue }
+            let childPrefix = prefix + (isLast ? "    " : "│   ")
+            try generate(url: content, depth: depth - 1, prefix: childPrefix)
         }
     }
 }

--- a/Tests/CeroxylonTests/CeroxylonTests.swift
+++ b/Tests/CeroxylonTests/CeroxylonTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import Ceroxylon
+
+final class CeroxylonTests: XCTestCase {
+    func testGeneratesProperConnectorsForNestedDirectories() throws {
+        let root = try makeTemporaryDirectory()
+        let alpha = root.appendingPathComponent("alpha", isDirectory: true)
+        let beta = root.appendingPathComponent("beta", isDirectory: true)
+        try FileManager.default.createDirectory(at: alpha, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: beta, withIntermediateDirectories: true)
+        FileManager.default.createFile(atPath: alpha.appendingPathComponent("a.txt").path, contents: Data())
+        FileManager.default.createFile(atPath: beta.appendingPathComponent("b.txt").path, contents: Data())
+
+        let output = try captureStandardOutput {
+            try TreeGenerator(
+                path: root.path,
+                depth: 10,
+                includesHidden: false
+            ).generate()
+        }
+
+        XCTAssertEqual(
+            output,
+            """
+            ```
+            ├── alpha
+            │   └── a.txt
+            └── beta
+                └── b.txt
+            ```
+            """
+        )
+    }
+
+    func testUsesLastBranchForFinalDirectory() throws {
+        let root = try makeTemporaryDirectory()
+        let folder = root.appendingPathComponent("folder", isDirectory: true)
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+
+        let output = try captureStandardOutput {
+            try TreeGenerator(
+                path: root.path,
+                depth: 10,
+                includesHidden: false
+            ).generate()
+        }
+
+        XCTAssertEqual(
+            output,
+            """
+            ```
+            └── folder
+            ```
+            """
+        )
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: url)
+        }
+        return url
+    }
+
+    private func captureStandardOutput(_ operation: () throws -> Void) throws -> String {
+        let pipe = Pipe()
+        let stdout = dup(STDOUT_FILENO)
+        XCTAssertNotEqual(stdout, -1)
+
+        fflush(stdout)
+        dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
+
+        do {
+            try operation()
+        } catch {
+            fflush(stdout)
+            dup2(stdout, STDOUT_FILENO)
+            close(stdout)
+            pipe.fileHandleForWriting.closeFile()
+            throw error
+        }
+
+        fflush(stdout)
+        dup2(stdout, STDOUT_FILENO)
+        close(stdout)
+        pipe.fileHandleForWriting.closeFile()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        pipe.fileHandleForReading.closeFile()
+
+        return String(decoding: data, as: UTF8.self)
+            .trimmingCharacters(in: .newlines)
+    }
+}

--- a/Tests/CeroxylonTests/CeroxylonTests.swift
+++ b/Tests/CeroxylonTests/CeroxylonTests.swift
@@ -67,8 +67,8 @@ final class CeroxylonTests: XCTestCase {
 
     private func captureStandardOutput(_ operation: () throws -> Void) throws -> String {
         let pipe = Pipe()
-        let stdout = dup(STDOUT_FILENO)
-        XCTAssertNotEqual(stdout, -1)
+        let savedStdout = dup(STDOUT_FILENO)
+        XCTAssertNotEqual(savedStdout, -1)
 
         fflush(stdout)
         dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
@@ -77,15 +77,15 @@ final class CeroxylonTests: XCTestCase {
             try operation()
         } catch {
             fflush(stdout)
-            dup2(stdout, STDOUT_FILENO)
-            close(stdout)
+            dup2(savedStdout, STDOUT_FILENO)
+            close(savedStdout)
             pipe.fileHandleForWriting.closeFile()
             throw error
         }
 
         fflush(stdout)
-        dup2(stdout, STDOUT_FILENO)
-        close(stdout)
+        dup2(savedStdout, STDOUT_FILENO)
+        close(savedStdout)
         pipe.fileHandleForWriting.closeFile()
 
         let data = pipe.fileHandleForReading.readDataToEndOfFile()

--- a/Tests/GrootTests/GrootTests.swift
+++ b/Tests/GrootTests/GrootTests.swift
@@ -1,4 +1,0 @@
-import XCTest
-@testable import Groot
-
-final class GrootTests: XCTestCase {}

--- a/install.sh
+++ b/install.sh
@@ -2,4 +2,4 @@
 swift package clean
 swift test
 swift build -c release
-cp .build/release/Groot $1/groot
+cp .build/release/Ceroxylon $1/ceroxylon

--- a/install.sh
+++ b/install.sh
@@ -3,3 +3,4 @@ swift package clean
 swift test
 swift build -c release
 cp .build/release/Ceroxylon $1/ceroxylon
+ln -sf $1/ceroxylon $1/xylon


### PR DESCRIPTION
## Summary

This PR marks a new start for the project under a new name: `Ceroxylon`.

The rename is meant to give the tool a more unique identity and a stronger personality, while keeping its original purpose as a simple CLI for generating directory tree views. Along with the rename, this PR includes a few small quality-of-life improvements around CLI behavior and test stability.

## Why

The previous name felt a bit generic. `Ceroxylon` gives the project a more distinctive character and a clearer identity going forward.

## Included in this PR

- Rename the project from `Groot` to `Ceroxylon`
- Update package, source, test, and README references
- Reserve `-h` for help and use `--hidden` as the hidden-files flag
- Fix test stdout capture issues in Xcode
- Add `xylon` as an install-time alias for the CLI
